### PR TITLE
Allow to change base path to correct work when using subpaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ docker run \
 
 > Check if Redis is Running and exposing ports!
 
+## Available variables
+
+See this `const` with [all available environments](https://github.com/tiagoboeing/bull-board/blob/1895a9c0b201d56d17ae2864cfcc0810a9b25dd3/src/index.ts#L15).
+
 ## Developing
 
 This project requires that you have a Redis instance running (you can simply run the `docker-compose.yml` to start the stack, use `npm run start:docker`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiagoboeing/bull-board",
-  "version": "0.0.0",
+  "version": "1.0.3-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiagoboeing/bull-board",
-      "version": "0.0.0",
+      "version": "1.0.3-0",
       "license": "MIT",
       "dependencies": {
         "@bull-board/api": "^4.8.0",
@@ -14,7 +14,8 @@
         "ansis": "^1.5.5",
         "bull": "^4.9.0",
         "bullmq": "^1.90.1",
-        "express": "^4.18.2"
+        "express": "^4.18.2",
+        "morgan": "^1.10.0"
       },
       "devDependencies": {
         "@babel/core": "^7.17.9",
@@ -31,6 +32,7 @@
         "@types/express": "^4.17.15",
         "@types/ioredis": "^4.28.10",
         "@types/jest": "^27.4.1",
+        "@types/morgan": "^1.9.4",
         "@types/node": "^17.0.25",
         "@types/redis-info": "^3.0.0",
         "@types/supertest": "^2.0.12",
@@ -3673,6 +3675,15 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
+    "node_modules/@types/morgan": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.4.tgz",
+      "integrity": "sha512-cXoc4k+6+YAllH3ZHmx4hf7La1dzUk6keTR4bF4b4Sc0mZxU/zK4wO7l+ZzezXm/jkYj/qC+uYGZrarZdIVvyQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "17.0.45",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
@@ -4769,6 +4780,22 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
@@ -12280,6 +12307,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/morgan/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/morgan/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -12633,6 +12707,14 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -19314,6 +19396,15 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
+    "@types/morgan": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.4.tgz",
+      "integrity": "sha512-cXoc4k+6+YAllH3ZHmx4hf7La1dzUk6keTR4bF4b4Sc0mZxU/zK4wO7l+ZzezXm/jkYj/qC+uYGZrarZdIVvyQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "17.0.45",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
@@ -20157,6 +20248,21 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
+    },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
     },
     "before-after-hook": {
       "version": "2.2.3",
@@ -25717,6 +25823,46 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -25975,6 +26121,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "ansis": "^1.5.5",
     "bull": "^4.9.0",
     "bullmq": "^1.90.1",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "morgan": "^1.10.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",
@@ -53,6 +54,7 @@
     "@types/express": "^4.17.15",
     "@types/ioredis": "^4.28.10",
     "@types/jest": "^27.4.1",
+    "@types/morgan": "^1.9.4",
     "@types/node": "^17.0.25",
     "@types/redis-info": "^3.0.0",
     "@types/supertest": "^2.0.12",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { BaseAdapter } from '@bull-board/api/dist/src/queueAdapters/base'
 import styles from 'ansis'
 import { splitQueueList } from './utils/split-queue-list/split-queue-list'
 import { handleBasePath } from './utils/base-path/base-path'
+import morgan from 'morgan'
 
 const environments = {
   port: process.env.PORT || 4000,
@@ -20,7 +21,7 @@ const environments = {
   redisHost: process.env.REDIS_HOST || 'localhost',
   redisUsername: process.env.REDIS_USERNAME || 'default',
   redisPassword: process.env.REDIS_PASSWORD || '',
-  basePath: process.env.BASE_PATH || '/'
+  apiBasePath: process.env.API_BASE_PATH || '/'
 }
 
 const redisOptions: ConnectionOptions = {
@@ -97,7 +98,7 @@ const run = async () => {
     })
   })
 
-  const basePath = handleBasePath(environments.basePath)
+  const basePath = handleBasePath(environments.apiBasePath)
 
   const serverAdapter: any = new ExpressAdapter()
   serverAdapter.setBasePath(basePath)
@@ -119,7 +120,7 @@ const run = async () => {
   console.log(`${queueBullMqList.map((queue) => `- ${queue.name}`).join('\n')}`)
   console.log('')
 
-  app.use('/', serverAdapter.getRouter())
+  app.use('/', morgan('short'), serverAdapter.getRouter())
 
   app.listen(environments.port, () => {
     console.log(`Running on ${environments.port}...`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import express from 'express'
 import { BaseAdapter } from '@bull-board/api/dist/src/queueAdapters/base'
 import styles from 'ansis'
 import { splitQueueList } from './utils/split-queue-list/split-queue-list'
+import { handleBasePath } from './utils/base-path/base-path'
 
 const environments = {
   port: process.env.PORT || 4000,
@@ -18,7 +19,8 @@ const environments = {
   redisPort: parseInt(process.env.REDIS_PORT || '6379'),
   redisHost: process.env.REDIS_HOST || 'localhost',
   redisUsername: process.env.REDIS_USERNAME || 'default',
-  redisPassword: process.env.REDIS_PASSWORD || ''
+  redisPassword: process.env.REDIS_PASSWORD || '',
+  basePath: process.env.BASE_PATH || '/'
 }
 
 const redisOptions: ConnectionOptions = {
@@ -95,8 +97,10 @@ const run = async () => {
     })
   })
 
+  const basePath = handleBasePath(environments.basePath)
+
   const serverAdapter: any = new ExpressAdapter()
-  serverAdapter.setBasePath('/bull-board')
+  serverAdapter.setBasePath(basePath)
 
   const adaptersList: BaseAdapter[] = []
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ const environments = {
   redisHost: process.env.REDIS_HOST || 'localhost',
   redisUsername: process.env.REDIS_USERNAME || 'default',
   redisPassword: process.env.REDIS_PASSWORD || '',
-  apiBasePath: process.env.API_BASE_PATH || '/'
+  basePath: process.env.BASE_PATH || '/'
 }
 
 const redisOptions: ConnectionOptions = {
@@ -53,7 +53,7 @@ const run = async () => {
   )
 
   console.log('Configs')
-  console.log(`- Api base path: ${environments.apiBasePath}`)
+  console.log(`- Api base path: ${environments.basePath}`)
   console.log(`- Prefix: ${environments.queuePrefix}`)
   console.log(`- Queues: ${environments.queueNames}`)
 
@@ -99,7 +99,7 @@ const run = async () => {
     })
   })
 
-  const basePath = handleBasePath(environments.apiBasePath)
+  const basePath = handleBasePath(environments.basePath)
   console.log(`Base path: ${basePath}`)
 
   const serverAdapter: any = new ExpressAdapter()

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ const run = async () => {
   })
 
   const serverAdapter: any = new ExpressAdapter()
-  serverAdapter.setBasePath('')
+  serverAdapter.setBasePath('/bull-board')
 
   const adaptersList: BaseAdapter[] = []
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ const run = async () => {
   )
 
   console.log('Configs')
+  console.log(`- Api base path: ${environments.apiBasePath}`)
   console.log(`- Prefix: ${environments.queuePrefix}`)
   console.log(`- Queues: ${environments.queueNames}`)
 
@@ -99,6 +100,7 @@ const run = async () => {
   })
 
   const basePath = handleBasePath(environments.apiBasePath)
+  console.log(`Base path: ${basePath}`)
 
   const serverAdapter: any = new ExpressAdapter()
   serverAdapter.setBasePath(basePath)

--- a/src/utils/base-path/base-path.spec.ts
+++ b/src/utils/base-path/base-path.spec.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from '@jest/globals'
+import { handleBasePath } from './base-path'
+
+describe('BasePath', () => {
+  test('should return "/" when path is undefined', () => {
+    expect(handleBasePath()).toBe('/')
+  })
+
+  test('should return "/" when path is "/"', () => {
+    expect(handleBasePath('/')).toBe('/')
+  })
+
+  test('should return path with "/" when passing without "/"', () => {
+    expect(handleBasePath('test')).toBe('/test')
+  })
+
+  test('should return path with "/" when passing with "/"', () => {
+    expect(handleBasePath('/test')).toBe('/test')
+  })
+
+  test('should work with subpaths', () => {
+    expect(handleBasePath('test/subpath')).toBe('/test/subpath')
+    expect(handleBasePath('/test/subpath')).toBe('/test/subpath')
+  })
+})

--- a/src/utils/base-path/base-path.ts
+++ b/src/utils/base-path/base-path.ts
@@ -1,0 +1,7 @@
+export const handleBasePath = (path?: string) => {
+  if (!path) return '/'
+  if (path === '/') return path
+  if (path.startsWith('/')) return path
+
+  return `/${path}`
+}


### PR DESCRIPTION
When deploying the Bull Board dashboard using a Kubernetes Ingress with subpaths, the page doesn't open.

- `example.com` --> Any website/API
- `example.com/bull-board` --> Bull Board Dashboard

The `base href` will be replaced to the value from "BASE_PATH" environment: 

![image](https://user-images.githubusercontent.com/3449932/234888143-9cc17d21-598c-4333-aa65-2765915d0022.png)

To correct work with subpaths, the Ingress should be created as the following way:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: bull-board
  annotations:
    nginx.ingress.kubernetes.io/rewrite-target: /$2
spec:
  ingressClassName: nginx
  rules:
    - host: example.com
      http:
        paths:
          - path: /bull-board(/?)(.*)
            pathType: Prefix
            backend:
              service:
                name: bull-board
                port:
                  number: 4000
```

> Using Nginx Ingress Controller

ConfigMap:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: bull-board
data:
  BASE_PATH: "bull-board"
```

## Local tests

Simply run: `QUEUE_NAMES=123 BASE_PATH=bull npm run start:dev`
